### PR TITLE
Docker-compose environmnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,22 @@ configurations as needed.
 
 Run with flask server and live reloading:
 ```
-> docker-compose -f docker-compose.base.yml -f docker-compose.fdev.yml up
+> docker-compose -f docker-compose.yml -f docker-compose.fdev.yml up
 ```
 
 Run with gunicorn server and live reloading:
 ```
-> docker-compose -f docker-compose.base.yml -f docker-compose.gdev.yml up
+> docker-compose -f docker-compose.yml -f docker-compose.gdev.yml up
+```
+
+Create enviroment to give commands such as pytest:
+```
+> docker-compose -f docker-compose.yml -f docker-compose.test.yml up
+> pytest
+```
+
+Run with gunicorn server and Traefik configurations:
+```
+> docker network create reverse_proxy # If not created will throw an error since file relies on externally created network
+> docker-compose -f docker-compose.yml -f docker-compose.production.yml up
 ```

--- a/docker-compose.fdev.yml
+++ b/docker-compose.fdev.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.5'
 services:
   personal:
     container_name: flask_personal
@@ -9,6 +9,8 @@ services:
       - FLASK_APP=app.run.py
       - FLASK_ENV=development
     command: ash -c " flask run -h 0.0.0.0 -p 5000"
+    ports:
+      - 5000:5000
 
   live-reloader:
     image: apogiatzis/livereloading

--- a/docker-compose.gdev.yml
+++ b/docker-compose.gdev.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.5'
 services:
   personal:
     container_name: flask_personal
@@ -8,6 +8,8 @@ services:
     environment:
       - FLASK_ENV=testing
     command: ash -c " gunicorn -w 2 -b 0.0.0.0:5000 'app:create_app()' "
+    ports:
+      - 5000:5000
 
   live-reloader:
     image: apogiatzis/livereloading

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,0 +1,27 @@
+version: '3.5'
+services:
+  personal:
+    # Traefik looks for the label to set up the routes automatically when deployed to production
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.flask-web.rule=Host(`example.net`) # Defines Domain name for HTTP
+      - traefik.http.routers.flask-web.entrypoints=web # Entry point defined within Traefik file
+      - traefik.http.routers.flask-web.middlewares=redirect@file # Redirects to https
+      - traefik.http.routers.flask-secure.rule=Host(`example.net`) # Defines HTTPS
+      - traefik.http.routers.flask-web.entrypoints=web-secured
+    # Not needed but defined for use with reverse proxy container
+    networks:
+      - reverse_proxy
+    environment:
+      - FLASK_APP=production
+    command: ash -c " gunicorn -w 2 -b 0.0.0.0:5000 'app:create_app()' "
+
+    # Exposed ports not needed since they will be picked up traefik if within the same docker-network
+
+# Not needed but defined for use with traefik
+# Create network before use or create through traefik docker-compose:
+# > docker network create reverse_proxy
+networks:
+  reverse_proxy:
+    name: reverse_proxy
+    external: true

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -4,6 +4,3 @@ services:
     container_name: flask_personal
     environment:
       - FLASK_ENV=testing
-    command: ash -c "gunicorn -w 2 -b 0.0.0.0:5000 'app:create_app()'"
-    ports:
-      - 5000:5000

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -4,3 +4,5 @@ services:
     container_name: flask_personal
     environment:
       - FLASK_ENV=testing
+    ports:
+      - 5000:5000

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -5,5 +5,3 @@ services:
     environment:
       - FLASK_ENV=testing
     command: ash -c "gunicorn -w 2 -b 0.0.0.0:5000 'app:create_app()'"
-    ports:
-      - 5000:5000

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,7 +1,9 @@
-version: '3'
+version: '3.5'
 services:
   personal:
     container_name: flask_personal
     environment:
       - FLASK_ENV=testing
     command: ash -c "gunicorn -w 2 -b 0.0.0.0:5000 'app:create_app()'"
+    ports:
+      - 5000:5000

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -4,5 +4,6 @@ services:
     container_name: flask_personal
     environment:
       - FLASK_ENV=testing
+    command: ash -c "gunicorn -w 2 -b 0.0.0.0:5000 'app:create_app()'"
     ports:
       - 5000:5000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,7 @@
-version: '3'
+version: '3.5'
 services:
   personal:
     build: src/
     container_name: flask_personal
     image: flask_app:1.0.0
     restart: always
-    environment:
-      - FLASK_APP=production
-    ports:
-      - 5000:5000


### PR DESCRIPTION
- Use of docker-compose to create multiple similar configurations with different environments.

- Production will use Traefik as a reverse proxy on the server which uses labels to automatically detect the application. No port exposure needed if within the same docker network as well.